### PR TITLE
Follow the new API for eServiceReference

### DIFF
--- a/ServiceReference.py
+++ b/ServiceReference.py
@@ -35,7 +35,7 @@ class ServiceReference(eServiceReference):
 
 	def isRecordable(self):
 		ref = self.ref
-		return ref.flags & eServiceReference.isGroup or (ref.type == eServiceReference.idDVB or ref.type == eServiceReference.idDVB + 0x100 or ref.type == 0x2000) # or ref.type == 0x1001) not work on libeplayer
+		return ref.flags & eServiceReference.isGroup or (ref.type in (eServiceReference.idDVB, eServiceReference.idDVB + eServiceReference.idServiceIsScrambled, eServiceReference.idServiceHDMIIn)) # eServiceReference.idServiceMP3 won't work on libeplayer
 
 def getPlayingref(ref):
 	playingref = None

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -13,7 +13,7 @@ from Components.MenuList import MenuList
 from Components.ServiceEventTracker import ServiceEventTracker, InfoBarBase
 profile("ChannelSelection.py 1")
 from Screens.EpgSelection import EPGSelection
-from enigma import eServiceReference, eEPGCache, eServiceCenter, eRCInput, eTimer, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode
+from enigma import eServiceReference, eServiceReferenceDVB, eEPGCache, eServiceCenter, eRCInput, eTimer, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode
 from Components.config import config, configfile, ConfigSubsection, ConfigText, ConfigYesNo
 from Tools.NumericalTextInput import NumericalTextInput
 profile("ChannelSelection.py 2")


### PR DESCRIPTION
sFileSize is deprecated now, see an example: https://github.com/OpenVisionE2/enigma2-openvision/commit/95a97dfee79f49b408f66ceabceae0f773ef7f64

Using hard-coded values for services is deprecated now, for example:

ref.type == 0x1001 is eServiceReference.idServiceMP3
ref.type == 0x2000 is eServiceReference.idServiceHDMIIn

See https://github.com/OpenVisionE2/enigma2-openvision/blob/develop/doc/SERVICEREF for detailed information.